### PR TITLE
fix: Azure login authentication with service principal

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -42,7 +42,6 @@ jobs:
       with:
         app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
         package: './functions'
-        publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
         
     - name: Azure logout
       if: always()


### PR DESCRIPTION
Remove publish-profile parameter from Functions deployment to rely solely on Service Principal authentication. This resolves 401 Unauthorized errors caused by conflicting authentication methods.